### PR TITLE
Validate preview/page inputs, centralize filtering logic, and tidy server imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,7 +1058,7 @@
                             <option value="sv">SV类</option>
                             <option value="utau">UTAU类</option>
                         </select>
-                        <input type="number" class="input" id="previewIndex" placeholder="期数" value="0" style="width: 80px;">
+                        <input type="number" class="input" id="previewIndex" placeholder="期数" value="1" min="1" style="width: 80px;">
                         <button class="btn btn-primary" id="calculateBtn">🧮 计算排行榜</button>
                     </div>
                 </div>
@@ -1256,7 +1256,7 @@
                             params.value = '{\n  "changes": [\n    {\n      "bvid": "BVxxx",\n      "ranks": ["domestic", "sv"],\n      "is_examined": true,\n      "is_republish": false\n    }\n  ]\n}';
                             break;
                         case '/api/calculate-rankings':
-                            params.value = '{\n  "rank": "domestic",\n  "index": 0,\n  "contain_unexamined": false,\n  "lock": false\n}';
+                            params.value = '{\n  "rank": "domestic",\n  "index": 1,\n  "contain_unexamined": false,\n  "lock": false\n}';
                             break;
                     }
                 });
@@ -1364,16 +1364,13 @@
 
             async loadVideos() {
                 const videoList = document.getElementById('videoList');
-                const keyword = document.getElementById('searchKeyword').value;
-                const rank = document.getElementById('rankFilter').value;
-                const examined = document.getElementById('examinedFilter').value;
-                const bvid = document.getElementById('bvidFilter').value;
                 const dateFilter = document.getElementById('dateFilter').value;
                 const pageSize = document.getElementById('pageSizeSelect').value;
-                const pageIndex = document.getElementById('currentPage').value || 1;
+                const pageIndex = Number(document.getElementById('currentPage').value) || 1;
 
                 if (dateFilter !== this.currentDate || pageSize !== this.currentPageSize || pageIndex !== this.currentPageIndex) {
                     videoList.innerHTML = '<div class="loading">正在向服务器请求数据...</div>';
+                    this.currentPageIndex = pageIndex;
                     if (dateFilter !== this.currentDate || pageSize !== this.currentPageSize) {
                         this.currentPageIndex = 1;
                     }
@@ -1409,7 +1406,20 @@
                     }
                 }
 
-                let videoData = this.filterVideos(this.videos, { keyword, rank, examined, bvid });
+                this.applyRecordingFilters();
+            }
+
+            getRecordingFilters() {
+                return {
+                    keyword: document.getElementById('searchKeyword').value,
+                    rank: document.getElementById('rankFilter').value,
+                    examined: document.getElementById('examinedFilter').value,
+                    bvid: document.getElementById('bvidFilter').value,
+                };
+            }
+
+            applyRecordingFilters() {
+                const videoData = this.filterVideos(this.videos, this.getRecordingFilters());
                 this.updateStats(videoData);
                 this.renderVideos(videoData);
                 this.pageButtons();
@@ -1680,13 +1690,12 @@
 
                 this.changes.set(bvid, { ...this.currentEditingData });
                 this.closeEditPanel();
-                this.renderVideos();
-                this.updateChangesPanel();
                 
                 this.videos = this.videos.map(v => 
                     v.bvid === bvid ? { ...v, ...this.currentEditingData } : v
                 );
-                this.updateStats();
+                this.applyRecordingFilters();
+                this.updateChangesPanel();
             }
 
             updateChangesPanel() {
@@ -1809,7 +1818,9 @@
 
             async calculateRankings() {
                 const rank = document.getElementById('previewRank').value;
-                const index = parseInt(document.getElementById('previewIndex').value) || 0;
+                const indexInput = Number.parseInt(document.getElementById('previewIndex').value, 10);
+                const index = Number.isNaN(indexInput) ? 1 : Math.max(1, indexInput);
+                document.getElementById('previewIndex').value = index;
                 const preview = document.getElementById('rankingPreview');
                 const authHeaders = this.getAuthHeaders();
                 

--- a/quick_start.py
+++ b/quick_start.py
@@ -3,8 +3,6 @@
 CVSE Quick Start
 """
 
-import sys
-
 def main():
     print("CVSE Quick Start")
     print("Dependencies: flask flask-cors pycapnp")

--- a/server.py
+++ b/server.py
@@ -7,15 +7,24 @@ Copyright (c) 2026 milkboy, yhtq
 """
 
 import asyncio
-import json
 import os
-import sys
 from datetime import datetime, timedelta
 from flask import Flask, jsonify, request, Response
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from waitress import serve
+import capnp
+from rpc_tools.api_client import (
+    CVSE_Client,
+    ModifyEntry,
+    RPCTime,
+    Rank,
+    capnp_to_Rank,
+    ModifyEntry_to_capnp,
+    Index_to_capnp,
+    bv_to_index,
+)
 
 app = Flask(__name__)
 CORS(app)
@@ -24,23 +33,6 @@ limiter = Limiter(
     key_func=get_remote_address,
     app=app,
     default_limits=["100 per minute"],
-)
-
-current_script_path = os.path.abspath(__file__)
-
-import capnp
-from rpc_tools.api_client import (
-    CVSE_Client,
-    ModifyEntry,
-    RPCTime,
-    Rank,
-    RankProtocol,
-    capnp_to_Rank,
-    Rank_to_capnp,
-    ModifyEntry_to_capnp,
-    Index_to_capnp,
-    av_to_index,
-    bv_to_index
 )
 
 CVSE_HOST = "47.104.152.246"


### PR DESCRIPTION
### Motivation
- Ensure page and ranking index inputs are sane (start from 1) to avoid off-by-one and invalid requests.
- Centralize video filtering and rendering so updates (edits, pagination, filters) consistently refresh the UI.
- Clean up server startup and RPC import code to remove unused imports and make initialization ordering clearer.

### Description
- In `index.html` set the preview index input to `value="1"` with `min="1"` and update the debug default for `/api/calculate-rankings` to use `"index": 1`.
- Parse `currentPage` as a `Number` and properly track `this.currentPageIndex`, moving logic to update `currentPageIndex` before requesting data.
- Introduced `getRecordingFilters()` and `applyRecordingFilters()` to centralize filter retrieval and application, and replaced direct filtering calls with `applyRecordingFilters()`.
- Hardened `calculateRankings()` input handling to coerce the preview index to an integer >= 1 and write it back to the input element.
- Update `saveChange()` to reapply filters and refresh the changes panel after persisting edits to `this.videos`.
- Tidy Python files by removing unused imports (`sys`, `json`) in `server.py` and `quick_start.py`, reorganizing Flask app initialization and RPC import list, and adjusting exported helper imports.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2122fceb08327bfaf7460141bd86a)